### PR TITLE
Add the IExtractorRequest interface to alter requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -365,6 +365,21 @@ The interface offers 3 hooks:
   filtered, stored and indexed.
 
 
+Adjust the download request
+===========================
+The ``ckanext.extractor.interfaces.IExtractorRequest`` interface can be
+used to alter the request made to download the file for extraction. A typical
+use case would be to add headers, that the remote server requires or to change
+the URL.
+
+The interface offers 1 hook:
+
+- ``extractor_before_request(request)`` is called before the request
+  is send to download the file for extraction. The ``request`` parameter
+  is a ``PreparedRequest`` object
+  `from the requests library <http://docs.python-requests.org/en/master/user/advanced/#prepared-requests>`_.
+
+
 Development
 ===========
 

--- a/README.rst
+++ b/README.rst
@@ -376,8 +376,8 @@ The interface offers 1 hook:
 
 - ``extractor_before_request(request)`` is called before the request
   is send to download the file for extraction. The ``request`` parameter
-  is a ``PreparedRequest`` object
-  `from the requests library <http://docs.python-requests.org/en/master/user/advanced/#prepared-requests>`_.
+  is a ``PreparedRequest`` object `from the requests library 
+  <http://docs.python-requests.org/en/master/user/advanced/#prepared-requests>`_.
 
 
 Development

--- a/ckanext/extractor/interfaces.py
+++ b/ckanext/extractor/interfaces.py
@@ -89,11 +89,13 @@ class IExtractorRequest(plugins.Interface):
     The hooks provide a possibility to change the parameters of the request,
     e.g. if the remote server requires certain headers or authorization tokens
     or to completly alter the URL.
-
     '''
     def extractor_before_request(self, request):
         '''
         Change the PreparedRequest object according to your needs
+        
+        This function must return a PreparedRequest object, which could be
+        the original one after modifying it.
 
         See the requests documentation for details:
         http://docs.python-requests.org/en/master/user/advanced/

--- a/ckanext/extractor/interfaces.py
+++ b/ckanext/extractor/interfaces.py
@@ -81,3 +81,21 @@ class IExtractorPostprocessor(plugins.Interface):
         according to ``ckanext.extractor.indexed_fields``.
         '''
 
+
+class IExtractorRequest(plugins.Interface):
+    '''
+    Plugin into the requests made to download content for extraction.
+
+    The hooks provide a possibility to change the parameters of the request,
+    e.g. if the remote server requires certain headers or authorization tokens
+    or to completly alter the URL.
+
+    '''
+    def extractor_before_request(self, request):
+        '''
+        Change the PreparedRequest object according to your needs
+
+        See the requests documentation for details:
+        http://docs.python-requests.org/en/master/user/advanced/
+        '''
+        return request


### PR DESCRIPTION
In order to change requests before downloading files, this commit
introduces a new interface, which provides a hook to make arbitrary
changes to the request object before the request is actually sent.