### PR TITLE
index update_dict: disable package_show validation

### DIFF
--- a/ckanext/extractor/tasks.py
+++ b/ckanext/extractor/tasks.py
@@ -87,7 +87,7 @@ def extract(ini_path, res_dict):
     # is changed, since our extraction task runs asynchronously and may
     # be finished only when the automatic index update has already run.
     pkg_dict = toolkit.get_action('package_show')(
-            {}, {'id': res_dict['package_id']})
+            {'validate': False}, {'id': res_dict['package_id']})
     index_for('package').update_dict(pkg_dict)
 
     for plugin in PluginImplementations(IExtractorPostprocessor):


### PR DESCRIPTION
validation should be disabled on package_show when re-indexing, e.g. https://github.com/ckan/ckan/blob/master/ckan/lib/search/__init__.py#L146

we could use the `use_default_schema` parameter instead but this change is more in line with existing ckan code (just in case there are some subtle differences I'm missing)